### PR TITLE
fix: cilium namespace

### DIFF
--- a/k3s-cluster/content/tutorials/handbook/cilium/_index.md
+++ b/k3s-cluster/content/tutorials/handbook/cilium/_index.md
@@ -62,6 +62,6 @@ cilium connectivity test
 To remove the `cilium-test` namespace and Hubble `port-forward`, run:
 
 ```shell
-kubectl delete namespace cilium-test -n kube-system
+kubectl delete namespace cilium-test
 ps aux | grep kubectl | grep -v grep | awk {'print $2'} | xargs kill
 ```


### PR DESCRIPTION
## WHY

Fix the `cilium` namespace command.

## WHAT

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## HOW

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new issues or warnings
